### PR TITLE
Redirect compiler-rt submodule to archived GitHub repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty/compiler-rt"]
 	path = 3rdparty/compiler-rt
-	url = http://llvm.org/git/compiler-rt
+	url = https://github.com/llvm-mirror/compiler-rt


### PR DESCRIPTION
This is probably not the greatest fix, as it doesn't track LLVM any longer.